### PR TITLE
fix: stabilize wiki workflow with forced commits

### DIFF
--- a/.github/workflows/automate-docs.yml
+++ b/.github/workflows/automate-docs.yml
@@ -2,6 +2,8 @@ name: Auto-Update Wiki & Project
 on:
   push:
     branches: [ "dev", "main" ]  # Trigger on PRs targeting dev
+  issues:
+    types: [opened]
 jobs:
   update:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'


### PR DESCRIPTION
## What Issue is being closed by this PR. Replace X below with the issue number
Closes #12

## What did we change?
- Stabilize wiki workflow with forced commits
- Trigger wiki update on every merge to dev

## Why are we doing this?
- Excellent engineering

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] npm i successfully run
- [ ] Unit tests passing and Documentation done
