### PR TITLE
fix: stabilize wiki workflow by running only on pr merges

### DIFF
--- a/.github/workflows/automate-docs.yml
+++ b/.github/workflows/automate-docs.yml
@@ -2,8 +2,6 @@ name: Auto-Update Wiki & Project
 on:
   push:
     branches: [ "dev", "main" ]  # Trigger on PRs targeting dev
-  issues:
-    types: [opened]
 jobs:
   update:
     if: github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]'


### PR DESCRIPTION
## What Issue is being closed by this PR. Replace X below with the issue number
Closes #X

## What did we change?
- Run wiki workflow after only PR merges

## Why are we doing this?
- Engineering excellence

## How was it tested?
- [x] Locally
- [x] Development Environment
- [ ] Not needed, changes very basic
- [ ] npm i successfully run
- [ ] Unit tests passing and Documentation done
